### PR TITLE
feat: add desktop notifications and timestamp tracking

### DIFF
--- a/MediaRotator/README.md
+++ b/MediaRotator/README.md
@@ -18,6 +18,7 @@ Intelligent content lifecycle management:
 - **Content Discovery**: MDBList `hd-movie-lists` integration for quality content
 - **Modular Design**: Separate components for cache, API handlers, and content fetching
 - **Automated Cleanup**: Removes oldest entries when quota exceeded
+- **Notifications**: Desktop alerts and timestamp logging on media changes
 
 ## Architecture / How it works
 
@@ -137,6 +138,10 @@ export MDBLIST_USER="hd-movie-lists"
 export ROTATING_MOVIES_PATH="/mnt/netstorage/Media/RotatingMovies"
 export ROTATING_TV_PATH="/mnt/netstorage/Media/RotatingTV"
 export CACHE_DB_PATH="$HOME/.media_rotation_cache.db"
+
+# Notifications
+export ENABLE_NOTIFICATIONS="true"
+export MEDIA_CHANGE_FILE="$PWD/last_media_change.txt"
 ```
 
 ### SQLite Cache Schema

--- a/MediaRotator/media_rotator.py
+++ b/MediaRotator/media_rotator.py
@@ -41,6 +41,8 @@ def check_required_env_vars():
         print("export RADARR_QUALITY_PROFILE_ID='1'      # Default shown")
         print("export SONARR_QUALITY_PROFILE_ID='1'      # Default shown")
         print("export SONARR_LANGUAGE_PROFILE_ID='1'     # Default shown")
+        print("export ENABLE_NOTIFICATIONS='true'      # Desktop notifications (default: true)")
+        print("export MEDIA_CHANGE_FILE='last_media_change.txt'  # Path to change timestamp")
         return False
     return True
 

--- a/MediaRotator/notifications.py
+++ b/MediaRotator/notifications.py
@@ -1,0 +1,43 @@
+"""Utilities for user notifications and change tracking."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+# Determine whether desktop notifications should be sent
+NOTIFICATIONS_ENABLED = os.getenv("ENABLE_NOTIFICATIONS", "true").lower() not in {
+    "0",
+    "false",
+    "no",
+}
+
+# File updated with the timestamp of the last media change
+DEFAULT_TIMESTAMP = Path(__file__).resolve().parent.parent / "last_media_change.txt"
+TIMESTAMP_FILE = Path(os.getenv("MEDIA_CHANGE_FILE", DEFAULT_TIMESTAMP))
+
+
+def notify_change(message: str) -> None:
+    """Send a desktop notification and update the change timestamp.
+
+    Parameters
+    ----------
+    message:
+        The message to display if notifications are enabled.
+    """
+    timestamp = datetime.now().isoformat()
+
+    if NOTIFICATIONS_ENABLED and shutil.which("notify-send"):
+        try:
+            subprocess.run(["notify-send", message], check=False)
+        except Exception as exc:  # pragma: no cover - notification failures are non-critical
+            print(f"⚠️ Failed to send notification: {exc}")
+
+    try:
+        TIMESTAMP_FILE.write_text(timestamp)
+    except Exception as exc:  # pragma: no cover - file write errors are non-critical
+        print(f"⚠️ Failed to update change timestamp: {exc}")
+

--- a/MediaRotator/radarr_handler.py
+++ b/MediaRotator/radarr_handler.py
@@ -1,5 +1,9 @@
+"""Helpers for interacting with the Radarr API."""
+
 import os
 import requests
+
+from notifications import notify_change
 
 RADARR_API_KEY = os.getenv("RADARR_API_KEY")
 RADARR_URL = os.getenv("RADARR_URL", "http://localhost:7878")
@@ -34,6 +38,7 @@ def add_movie_to_radarr(movie_data):
     res = requests.post(f"{RADARR_URL}/api/v3/movie", headers=HEADERS, json=payload)
     if res.status_code == 201:
         print(f"✅ Added movie: {movie_data['title']} ({movie_data['year']})")
+        notify_change(f"Added movie: {movie_data['title']}")
         return True
     elif res.status_code == 400 and "already exists" in res.text.lower():
         print(f"⚠️ Movie already exists in Radarr: {movie_data['title']}")
@@ -59,6 +64,7 @@ def delete_movie_by_imdb(imdb_id, delete_files=True):
             )
             if del_res.status_code == 200:
                 print(f"🗑️ Deleted movie: {movie['title']}")
+                notify_change(f"Deleted movie: {movie['title']}")
                 return True
     print(f"⚠️ No matching movie found to delete with IMDb ID {imdb_id}")
     return False

--- a/MediaRotator/sonarr_handler.py
+++ b/MediaRotator/sonarr_handler.py
@@ -1,5 +1,9 @@
+"""Helpers for interacting with the Sonarr API."""
+
 import os
 import requests
+
+from notifications import notify_change
 
 SONARR_API_KEY = os.getenv("SONARR_API_KEY")
 SONARR_URL = os.getenv("SONARR_URL", "http://localhost:8989")
@@ -38,6 +42,7 @@ def add_show_to_sonarr(show_data):
     res = requests.post(f"{SONARR_URL}/api/v3/series", headers=HEADERS, json=payload)
     if res.status_code == 201:
         print(f"Added show: {show_data['title']}")
+        notify_change(f"Added show: {show_data['title']}")
         return True
     elif res.status_code == 400 and "already exists" in res.text.lower():
         print(f"Show already exists in Sonarr: {show_data['title']}")
@@ -63,6 +68,7 @@ def delete_show_by_tvdb(tvdb_id, delete_files=True):
             )
             if del_res.status_code == 200:
                 print(f"🗑️ Deleted show: {show['title']}")
+                notify_change(f"Deleted show: {show['title']}")
                 return True
     print(f"No matching show found to delete with TVDB ID {tvdb_id}")
     return False

--- a/last_media_change.txt
+++ b/last_media_change.txt
@@ -1,0 +1,1 @@
+No changes recorded yet.


### PR DESCRIPTION
## Summary
- notify users about media additions/removals with configurable `notify-send`
- track last library change via timestamp file
- document notification env vars in MediaRotator README

## Testing
- `python -m py_compile MediaRotator/*.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689acf5c37a88329b2ba2bdd2f61844a