### PR TITLE
Add Trakt fallback for MDBList outages

### DIFF
--- a/MediaRotator/README.md
+++ b/MediaRotator/README.md
@@ -5,7 +5,7 @@
 MediaRotator is an intelligent disk space management system that maintains 4TB quotas for rotating media collections while preventing duplicate imports through SQLite caching.
 
 - **Purpose**: Automated media rotation with disk quota enforcement
-- **Integration**: Connects MDBList curated content with Radarr/Sonarr APIs
+- **Integration**: Connects MDBList curated content (with Trakt fallback) with Radarr/Sonarr APIs
 - **Status**: Production-ready modular Python components
 
 ## Features
@@ -15,7 +15,7 @@ Intelligent content lifecycle management:
 - **Quota Management**: Enforces 4TB limits on rotating media folders
 - **Import Caching**: SQLite database prevents duplicate content acquisition
 - **API Integration**: Seamless Radarr/Sonarr media addition and search triggering
-- **Content Discovery**: MDBList `hd-movie-lists` integration for quality content
+- **Content Discovery**: MDBList `hd-movie-lists` integration for quality content with fallback to Trakt trending lists
 - **Modular Design**: Separate components for cache, API handlers, and content fetching
 - **Automated Cleanup**: Removes oldest entries when quota exceeded
 - **Notifications**: Desktop alerts and timestamp logging on media changes
@@ -29,13 +29,14 @@ Modular Python architecture with SQLite persistence:
 - **cache.py**: SQLite database operations for import tracking
 - **radarr_handler.py**: Radarr API integration for movie management
 - **sonarr_handler.py**: Sonarr API integration for TV show management
-- **mdblist_fetcher.py**: MDBList API client for content discovery
+- **mdblist_fetcher.py**: MDBList API client with Trakt fallback
+- **trakt_fetcher.py**: Trakt API client for trending lists
 
 ### Data Flow
 
 1. **Disk monitoring**: Check storage usage for rotating media folders
 2. **Quota enforcement**: Remove oldest cached entries when over 4TB limit
-3. **Content discovery**: Fetch curated lists from MDBList API
+3. **Content discovery**: Fetch curated lists from MDBList API (fallback to Trakt trending lists when necessary)
 4. **Cache validation**: Check SQLite database to prevent duplicate imports
 5. **Media addition**: Add new content via Radarr/Sonarr APIs
 6. **Search triggering**: Initiate download process for added content
@@ -46,6 +47,7 @@ Modular Python architecture with SQLite persistence:
 - **Radarr API**: Movie collection management and search triggering
 - **Sonarr API**: TV show collection management and search triggering
 - **MDBList API**: Curated HD movie and TV show list source
+- **Trakt API**: Trending list fallback when MDBList is unavailable
 - **SQLite**: Local caching and import history persistence
 
 ## Prerequisites
@@ -57,7 +59,7 @@ System requirements for media rotation management:
 - **Operating System**: Linux with Python 3.6+
 - **Memory**: 512MB RAM minimum for SQLite operations
 - **Storage**: Access to media paths (`/mnt/netstorage/Media/Rotating*`)
-- **Network**: API access to Radarr, Sonarr, and MDBList services
+- **Network**: API access to Radarr, Sonarr, MDBList, and Trakt services
 
 ### Dependencies
 
@@ -76,6 +78,7 @@ Required for full functionality:
 - **RADARR_API_KEY**: Radarr instance API access
 - **SONARR_API_KEY**: Sonarr instance API access
 - **MDBLIST_API_KEY**: MDBList API for content discovery
+- **TRAKT_CLIENT_ID**: Trakt API key for trending list fallback
 
 ## Installation
 
@@ -235,7 +238,7 @@ from mdblist_fetcher import *
 
 1. **Check disk size of media folder**
 2. **If over 4TB**: Delete oldest imported entry (and remove from Radarr/Sonarr too)
-3. **Fetch lists**: Get curated content from `HD Movie Lists` on MDBList
+3. **Fetch lists**: Get curated content from `HD Movie Lists` on MDBList (fallback to Trakt trending lists if MDBList fails)
 4. **Load cache**: Read previously imported IDs from SQLite
 5. **Process lists**: For each list, find content not in Radarr/Sonarr AND not in cache
 6. **Add content**: Add via API, trigger search, and record in cache
@@ -397,7 +400,7 @@ This project is licensed under the MIT License - see [LICENSE](../LICENSE) file 
 - [ ] SQLite cache prevents duplicate imports
 - [ ] Disk quota monitoring accurately enforces 4TB limits
 - [ ] Content rotation removes oldest entries when quota exceeded
-- [ ] MDBList integration provides quality content recommendations
+- [ ] MDBList integration provides quality content recommendations (Trakt fallback available)
 - [ ] Cache persists between runs and system restarts
 - [ ] Environment variables provide clean configuration
 - [ ] Error handling captures and logs issues appropriately

--- a/MediaRotator/mdblist_fetcher.py
+++ b/MediaRotator/mdblist_fetcher.py
@@ -1,4 +1,13 @@
+"""Fetch curated lists from MDBList with Trakt fallback.
+
+This module retrieves movie and show identifiers from MDBList. If the
+service is unavailable, it falls back to pulling trending items from the
+Trakt API.
+"""
+
 import requests
+
+from trakt_fetcher import get_trending_items
 
 MDBLIST_BASE_URL = "https://mdblist.com/api"
 USER = "hd-movie-lists"
@@ -17,7 +26,15 @@ def get_items_from_list(slug):
 
 
 def get_all_items_from_all_lists():
-    lists = get_all_lists()
+    """Yield all items from MDBList lists or Trakt if MDBList fails."""
+    try:
+        lists = get_all_lists()
+    except Exception as e:
+        print(f"⚠️ MDBList unavailable: {e}")
+        print("➡️ Falling back to Trakt trending items")
+        yield from get_trending_items()
+        return
+
     for lst in lists:
         slug = lst["slug"]
         title = lst["title"]

--- a/MediaRotator/trakt_fetcher.py
+++ b/MediaRotator/trakt_fetcher.py
@@ -1,0 +1,68 @@
+"""Utilities for fetching trending media from the Trakt API.
+
+This module provides simple helpers to retrieve trending movies and
+television shows from Trakt. It is used as a fallback when MDBList is
+unavailable.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Generator
+
+import requests
+
+TRAKT_BASE_URL = "https://api.trakt.tv"
+CLIENT_ID = os.getenv("TRAKT_CLIENT_ID", "")
+HEADERS = {
+    "Content-Type": "application/json",
+    "trakt-api-key": CLIENT_ID,
+    "trakt-api-version": "2",
+}
+
+
+def _get(endpoint: str, params: Dict[str, int] | None = None) -> list[dict]:
+    """Internal helper to perform a GET request to the Trakt API."""
+    res = requests.get(f"{TRAKT_BASE_URL}{endpoint}", headers=HEADERS, params=params)
+    res.raise_for_status()
+    return res.json()
+
+
+def get_trending_items(limit: int = 50) -> Generator[dict, None, None]:
+    """Yield trending movies and shows from Trakt.
+
+    Args:
+        limit: Maximum number of movies and shows to retrieve for each type.
+
+    Yields:
+        Dictionary items compatible with MediaRotator's list processing.
+    """
+    # Trending movies
+    for entry in _get("/movies/trending", params={"limit": limit}):
+        movie = entry.get("movie", {})
+        ids = movie.get("ids", {})
+        imdb_id = ids.get("imdb") or ids.get("tmdb")
+        if not imdb_id:
+            continue
+        yield {
+            "id": imdb_id,
+            "type": "movie",
+            "title": movie.get("title"),
+            "slug": "trakt-trending-movies",
+            "list_title": "Trakt Trending Movies",
+        }
+
+    # Trending shows
+    for entry in _get("/shows/trending", params={"limit": limit}):
+        show = entry.get("show", {})
+        ids = show.get("ids", {})
+        tvdb_id = ids.get("tvdb") or ids.get("tmdb")
+        if not tvdb_id:
+            continue
+        yield {
+            "id": tvdb_id,
+            "type": "show",
+            "title": show.get("title"),
+            "slug": "trakt-trending-shows",
+            "list_title": "Trakt Trending Shows",
+        }

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ MediaCycler is a media management suite that rotates libraries under disk quotas
 
 **What it does**: MediaCycler provides intelligent media lifecycle management by automatically discovering, importing, and rotating content within defined storage limits. It maintains quality through selective imports, health checks, and on-demand transcoding, while making your media easily accessible through IPTV channel endpoints.
 
-**Key Integrations**: Seamlessly integrates with Radarr, Sonarr, Jellyfin, MDBList, Threadfin, Tunarr, and Trailarr to create a complete media automation ecosystem.
+**Key Integrations**: Seamlessly integrates with Radarr, Sonarr, Jellyfin, MDBList, Trakt, Threadfin, Tunarr, and Trailarr to create a complete media automation ecosystem.
 
 **Philosophy**: Import one at a time to maintain quality and storage limits. Make streaming easy via IPTV endpoints. Quality over quantity, with intelligent curation and automatic cleanup to keep your media collection fresh and within disk constraints.
 
 ## Key Features
 
 - **Disk quota-aware media rotation (Movies and TV)** with cached import tracking using SQLite database
-- **Automated list ingestion from MDBList** "HD Movie Lists" for curated content discovery
+- **Automated list ingestion from MDBList** "HD Movie Lists" for curated content discovery with fallback to Trakt trending lists
 - **Radarr/Sonarr add, search, and cleanup flows** with automatic removal when quota exceeded
 - **Health checks of media with ffmpeg** and on-demand transcoding via Encodarr webhook integration
 - **Jellyfin utility scripts** including genre tagging from folder layout and collection management
@@ -161,7 +161,7 @@ export SONARR_LANGUAGE_PROFILE_ID="1"
   - Transcoded output: `/mnt/netstorage/Media/Transcoded`
   - transcode.sh path: `/app/transcode.sh` if containerized; otherwise point to `Encodarr/transcode.sh`
 
-- **MDBList pulls from user hd-movie-lists (no API key currently used).**
+- **MDBList pulls from user hd-movie-lists (no API key currently used); fallback to Trakt trending lists requires `TRAKT_CLIENT_ID`.**
 
 ## Secrets
 

--- a/example.env
+++ b/example.env
@@ -6,3 +6,6 @@ export SONARR_API_KEY="..."
 export SONARR_URL="http://localhost:8989"
 export SONARR_QUALITY_PROFILE_ID="1"
 export SONARR_LANGUAGE_PROFILE_ID="1"
+
+# Optional Trakt configuration for list fallback
+export TRAKT_CLIENT_ID="..."


### PR DESCRIPTION
## Summary
- add Trakt trending fetcher for movie and show IDs
- fallback to Trakt when MDBList requests fail
- document Trakt integration and optional `TRAKT_CLIENT_ID` env var

## Testing
- `python -m py_compile MediaRotator/trakt_fetcher.py MediaRotator/mdblist_fetcher.py MediaRotator/media_rotator.py`


------
https://chatgpt.com/codex/tasks/task_e_689ae2dde9148329b2d6cfe456b101ff