### PR TITLE
feat: add MediaRotator service to docker-compose

### DIFF
--- a/MediaRotator/Dockerfile
+++ b/MediaRotator/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy MediaRotator source
+COPY . ./
+RUN chmod +x run_rotator.sh
+
+# Run the rotator on a simple hourly schedule
+CMD ["bash", "run_rotator.sh"]

--- a/MediaRotator/requirements.txt
+++ b/MediaRotator/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/MediaRotator/run_rotator.sh
+++ b/MediaRotator/run_rotator.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Simple scheduler for MediaRotator; runs the rotation script every hour.
+set -e
+
+while true; do
+  python media_rotator.py
+  sleep 3600
+done

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ docker-compose up -d
 - ✅ **MediaRotator CLI implemented** - Main automation script was missing, now complete
 - ✅ **Security fix** - Removed hard-coded API key from genre tagging script
 - ✅ **Docker typo fixed** - Fixed `unless-stopped` in trailarr configuration
-- ✅ **Root orchestration** - Added main docker-compose.yml for all services
+- ✅ **Root orchestration** - Main docker-compose now runs MediaRotator alongside Threadfin, Trailarr, and Encodarr
 - ✅ **Automated cron setup** - Script to install scheduled tasks automatically
 - ✅ **Environment template** - Complete .env.example with all required variables
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - mediacycler
 
   encodarr:
-    build: 
+    build:
       context: ./Encodarr
       dockerfile: Dockerfile
     container_name: mediacycler-encodarr
@@ -47,6 +47,27 @@ services:
     volumes:
       - /mnt/netstorage/Media:/media:rw
       - ./Encodarr/logs:/app/logs
+    restart: unless-stopped
+    networks:
+      - mediacycler
+
+  mediarotator:
+    build:
+      context: ./MediaRotator
+      dockerfile: Dockerfile
+    container_name: mediacycler-rotator
+    environment:
+      - TZ=America/New_York
+      - RADARR_API_KEY=${RADARR_API_KEY}
+      - SONARR_API_KEY=${SONARR_API_KEY}
+      - RADARR_URL=${RADARR_URL}
+      - SONARR_URL=${SONARR_URL}
+      - RADARR_QUALITY_PROFILE_ID=${RADARR_QUALITY_PROFILE_ID}
+      - SONARR_QUALITY_PROFILE_ID=${SONARR_QUALITY_PROFILE_ID}
+      - SONARR_LANGUAGE_PROFILE_ID=${SONARR_LANGUAGE_PROFILE_ID}
+    volumes:
+      - mediarotator_cache:/root
+      - ./last_media_change.txt:/app/last_media_change.txt
     restart: unless-stopped
     networks:
       - mediacycler
@@ -78,4 +99,6 @@ volumes:
   trailarr_data:
     driver: local
   encodarr_logs:
+    driver: local
+  mediarotator_cache:
     driver: local


### PR DESCRIPTION
## Summary
- containerize MediaRotator with an hourly scheduler
- unify threadfin, trailarr, encodarr, and MediaRotator under one docker-compose
- document MediaRotator inclusion in README

## Testing
- `bash -n MediaRotator/run_rotator.sh`
- `python -m py_compile MediaRotator/media_rotator.py`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ee21f143483298020b76d7d17290c