### PR TITLE
docs(readme): document testing coverage workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,18 @@ initialize_cache_db()
 "
 ```
 
+## Testing & Coverage
+
+Run tests for each service with coverage reporting enabled to validate functionality.
+
+```bash
+# Python services
+pytest --cov --maxfail=1 -q
+
+# Tunarr (Node)
+npm test -- --coverage
+```
+
 ## Security
 
 ### Access Control

--- a/docs/README_TEMPLATE.md
+++ b/docs/README_TEMPLATE.md
@@ -86,6 +86,16 @@ cp config.example.yml config.yml
 ./start-service.sh
 ```
 
+## Testing & Coverage
+
+```bash
+# Run Python tests with coverage
+pytest --cov --maxfail=1 -q
+
+# Run Node tests with coverage
+npm test -- --coverage
+```
+
 ## Configuration
 
 ### Environment Variables


### PR DESCRIPTION
## Summary
- document test coverage workflow in the project README
- add testing and coverage guidance to README template for components

## Testing
- `pytest --cov --maxfail=1 -q` (no tests run)


------
https://chatgpt.com/codex/tasks/task_e_68bf0d8012648329be04460a50d391fd