### PR TITLE
feat: add subtitle conversion script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,6 +8,8 @@ Collection of utility scripts for automated media management, focusing on Jellyf
 - **Status**: Production-ready shell scripts with robust error handling
 
 ## Features
+- **Subtitle Conversion**: Recursively convert ASS subtitles to SRT format using ffmpeg
+
 Jellyfin automation capabilities:
 - **Genre Tagging**: Automatic genre assignment based on folder structure
 - **Collection Management**: Create and maintain genre-based collections
@@ -20,6 +22,7 @@ Jellyfin automation capabilities:
 Shell-based automation with API integration:
 
 ### Core Components
+- **convert_ass_to_srt.sh**: Recursively convert ASS subtitle files to SRT format
 - **tag_tv_genres.sh**: Jellyfin TV genre tagging and collection automation
 
 ### Data Flow

--- a/scripts/convert_ass_to_srt.sh
+++ b/scripts/convert_ass_to_srt.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+# Recursively scan for .ass subtitle files and convert to .srt
+# Requires: ffmpeg
+
+MEDIA_DIR="/mnt/netstorage/Media"
+
+find "$MEDIA_DIR" -type f -name "*.ass" | while IFS= read -r assfile; do
+    srtfile="${assfile%.*}.srt"
+
+    if [ -f "$srtfile" ]; then
+        echo "Skipping (already exists): $srtfile"
+        continue
+    fi
+
+    echo "Converting: $assfile -> $srtfile"
+    if ffmpeg -y -i "$assfile" "$srtfile" >/dev/null 2>&1; then
+        echo "Success: $srtfile"
+    else
+        echo "Failed: $assfile"
+    fi
+done


### PR DESCRIPTION
## Summary
- add utility script to convert ASS subtitles to SRT using ffmpeg
- document subtitle conversion script in scripts README

## Testing
- `bash -n scripts/convert_ass_to_srt.sh`
- `shellcheck scripts/convert_ass_to_srt.sh` *(fails: command not found)*
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c26c6b2e088329a2e838c80194f0ed